### PR TITLE
Scale video such that the shorter side is 256

### DIFF
--- a/video_loader.py
+++ b/video_loader.py
@@ -67,7 +67,8 @@ class HT100M_DataLoader(Dataset):
             aw, ah = random.uniform(0, 1), random.uniform(0, 1)
         if self.crop_only:
             cmd = (
-                cmd.crop('(iw - {})*{}'.format(self.size, aw),
+                cmd.filter('scale', 'if(gt(ih, iw), 256, -1)', 'if(gt(ih, iw), -1, 256)')
+                   .crop('(iw - {})*{}'.format(self.size, aw),
                          '(ih - {})*{}'.format(self.size, ah),
                          str(self.size), str(self.size))
             )


### PR DESCRIPTION
Rescaling the input resolution to match the dimensions from HowTo100M [release](https://www.di.ens.fr/willow/research/howto100m/) regardless of the original video resolution.